### PR TITLE
Generalize CDCF governance framework for all technology projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Governance Frameworks
+# CDCF Foundation Governance Frameworks
 
 [![Status](https://img.shields.io/badge/status-working%20draft-yellow?style=flat-square)](https://github.com/mj3b/governance-frameworks)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](./LICENSE)
-[![Version](https://img.shields.io/badge/version-v0.1-lightgrey?style=flat-square)](https://github.com/mj3b/governance-frameworks)
+[![Version](https://img.shields.io/badge/version-v0.2-lightgrey?style=flat-square)](https://github.com/mj3b/governance-frameworks)
 [![CDCF](https://img.shields.io/badge/foundation-Catholic%20Digital%20Commons-8B0000?style=flat-square)](https://catholicdigitalcommons.org)
-[![Grounded in](https://img.shields.io/badge/grounded%20in-Antiqua%20et%20Nova%202025-gold?style=flat-square)](https://www.vatican.va/roman_curia/congregations/cfaith/documents/rc_ddf_doc_20250128_antiqua-et-nova_en.html)
+[![Grounded in](https://img.shields.io/badge/grounded%20in-Catholic%20Tradition-gold?style=flat-square)](https://www.vatican.va)
 
 > *"Before accepting a project as incubating, the CDCF must determine whether its scope meets the requirements for a CDCF Project — respectful of human dignity, conducive to human flourishing, and of potential service to the Church at a wide level."*
 >
@@ -20,37 +20,50 @@ A working repository for governance documentation supporting the **Catholic Digi
 
 ## What This Repository Is
 
-Catholic institutions serving tens of millions of people across healthcare, education, social services, and parish life are deploying AI without a shared, canonical standard for what responsible Catholic deployment looks like. This repository addresses that gap.
+This repository holds the policy frameworks, evaluation criteria, and research documentation that inform how the CDCF reviews, incubates, and graduates technology projects. It is modeled on established foundation governance (such as the Apache Software Foundation) but is uniquely grounded in Catholic Social Teaching and Canon Law.
 
-It holds the policy frameworks, evaluation criteria, and research documentation that inform how the CDCF reviews, incubates, and graduates technology projects submitted for consideration. The documents are initial working drafts: versioned, iterable, and open to contribution from the CDCF community, member dioceses, and Catholic technology practitioners worldwide.
-
----
-
-## The Two-Gate Framework
-
-Every technology project submitted to the CDCF passes through two evaluation gates before reaching active project status.
-
-| Gate | Stage | What It Evaluates |
-|:---|:---|:---|
-| **Gate 1** | Incubation Acceptance | Mission alignment · Human accountability architecture · Transparency of scope · Independent validation · Subgroup performance · Deployment governance specification |
-| **Gate 2** | Graduation to Active Status | Documentation for independent deployment · Data stewardship · Governance, maintenance, and subsidiarity compatibility |
-
-A project satisfying Gate 1 in full enters incubation. Graduation requires that Gate 1 criteria remain satisfied and that Gate 2 requirements are met. The gate structure applies to AI tools now and is designed for extension to technology projects more broadly.
+The documentation is organized into a general project governance framework, applicable to all technology projects, and specialized domain-specific criteria (starting with AI governance).
 
 ---
 
 ## Document Stack
 
-### AI Governance
+### General Project Governance
+
+The core frameworks for any project seeking CDCF endorsement.
 
 | Document | Type | Description |
 |:---|:---|:---|
-| [ai-vetting-criteria.md](./ai-governance/ai-vetting-criteria.md) | **Policy** | Operational vetting criteria for AI tools submitted to the CDCF. Two evaluation gates, eight criteria. The primary policy document. |
-| [fragmented-catholic-ai-governance.md](./ai-governance/fragmented-catholic-ai-governance.md) | Research memo | Why shared AI governance standards are urgent: three dioceses building in isolation, an accelerating fragmentation curve, and what a shared canonical baseline resolves. |
-| [governance-as-code-catholic-ai.md](./ai-governance/governance-as-code-catholic-ai.md) | Research memo | Machine-enforceable deployment governance: turning policy documents into version-controlled schemas wired into deployment pipelines as hard gates. |
-| [trusted-synthetic-data-ministry-ai.md](./ai-governance/trusted-synthetic-data-ministry-ai.md) | Research memo | Synthetic data infrastructure for ministry-scale AI development across Catholic healthcare, education, and social services. |
+| [project-vetting-criteria.md](./project-governance/project-vetting-criteria.md) | **Policy** | The foundational 8 criteria for any CDCF project. |
+| [lifecycle.md](./project-governance/lifecycle.md) | Procedure | Definition of the stages from proposal through incubation, graduation, and retirement. |
+| [committees.md](./project-governance/committees.md) | Structure | Governance bodies: Board of Directors, TCSC, and PMCs. |
+| [definitions.md](./project-governance/definitions.md) | Glossary | Shared vocabulary for CDCF governance and vetting. |
 
-The three research memos form an integrated argument. The fragmentation memo establishes why shared standards are urgent. The governance-as-code memo provides the deployment enforcement architecture. The trusted synthetic data memo provides the data infrastructure that allows Catholic institutions to develop AI worthy of that governance architecture.
+---
+
+### Specialized Domain Governance
+
+Domain-specific extensions to the general framework.
+
+#### AI Governance
+
+| Document | Type | Description |
+|:---|:---|:---|
+| [ai-vetting-criteria.md](./ai-governance/ai-vetting-criteria.md) | **Policy** | Operational vetting criteria for AI tools, extending the general framework. |
+| [fragmented-catholic-ai-governance.md](./ai-governance/fragmented-catholic-ai-governance.md) | Research memo | The urgency of shared AI governance standards. |
+| [governance-as-code-catholic-ai.md](./ai-governance/governance-as-code-catholic-ai.md) | Research memo | Machine-enforceable deployment governance architecture. |
+| [trusted-synthetic-data-ministry-ai.md](./ai-governance/trusted-synthetic-data-ministry-ai.md) | Research memo | Synthetic data infrastructure for ministry-scale AI. |
+
+---
+
+## The Two-Gate Framework
+
+Every technology project submitted to the CDCF passes through two evaluation gates.
+
+| Gate | Stage | What It Evaluates |
+|:---|:---|:---|
+| **Gate 1** | Incubation Acceptance | Mission alignment · Human accountability architecture · Transparency · Validation · Impact on vulnerable populations · Governance specification |
+| **Gate 2** | Graduation to Active Status | Documentation for independent deployment · Data stewardship · Maintenance and subsidiarity compatibility |
 
 ---
 
@@ -79,20 +92,7 @@ All documents are working drafts under active development. Version numbers refle
 
 > 💡 **This repository is an open governance commons.** The standards here belong to the Catholic community. Every diocese, health system, school, and ministry that contributes makes them stronger.
 
-This repository welcomes contributions from:
-
-- CDCF board members and advisors
-- Member dioceses and bishops conferences
-- Catholic technology practitioners and researchers
-- C-DART (Catholic Deep AI Research Team) community members
-
 Please open an issue before submitting a significant revision so the community can discuss the proposed change before it is incorporated.
-
----
-
-## Initial Contribution
-
-The AI governance documents were developed by **Mark Julius Banasihan** ([@mj3b](https://github.com/mj3b)), a lay Catholic AI governance researcher, in dialogue with U.S.A. C-DART 1 and submitted to the CDCF in March 2026 at the invitation of Father John Romano D'Orazio.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The core frameworks for any project seeking CDCF endorsement.
 | [project-vetting-criteria.md](./project-governance/project-vetting-criteria.md) | **Policy** | The foundational 8 criteria for any CDCF project. |
 | [lifecycle.md](./project-governance/lifecycle.md) | Procedure | Definition of the stages from proposal through incubation, graduation, and retirement. |
 | [committees.md](./project-governance/committees.md) | Structure | Governance bodies: Board of Directors, TCSC, and PMCs. |
+| [project-types.md](./project-governance/project-types.md) | Policy | Distinction between Foundation Projects and Community Projects. |
 | [definitions.md](./project-governance/definitions.md) | Glossary | Shared vocabulary for CDCF governance and vetting. |
 
 ---

--- a/ai-governance/ai-vetting-criteria.md
+++ b/ai-governance/ai-vetting-criteria.md
@@ -4,7 +4,7 @@
 |:---|:---|
 | **Version** | v0.1 (draft for community review) |
 | **Scope** | AI-assisted tools submitted for CDCF incubation and graduation |
-| **Extensibility** | Scoped to AI tools. The underlying framework is designed for extension to software projects more broadly; a generalized version is anticipated in a subsequent release. |
+| **Relationship** | This is a domain-specific extension of the [General Project Vetting Criteria](../project-governance/project-vetting-criteria.md). |
 
 ---
 

--- a/project-governance/committees.md
+++ b/project-governance/committees.md
@@ -1,0 +1,35 @@
+# CDCF Governance Bodies
+
+This document outlines the governance structure for CDCF technology projects, based on principles of Catholic governance and established open-source models.
+
+---
+
+## 1. CDCF Board of Directors
+
+The highest level of oversight for the Catholic Digital Commons Foundation.
+
+- **Responsibility:** Final authority on mission alignment, canonical scope, and overall Foundation strategy.
+- **Authority:** Approves new projects for incubation and graduation based on recommendations from specialized committees.
+
+## 2. Technical and Canonical Standards Committee (TCSC)
+
+A central body responsible for defining and maintaining the CDCF Project Vetting Criteria and related technical standards.
+
+- **Composition:** Experts in Catholic theology, canon law, technology, and governance.
+- **Responsibility:** Reviewing project proposals and evaluating incubating projects against the Gate 1 and Gate 2 criteria.
+
+## 3. Project Management Committee (PMC)
+
+Each active CDCF project is governed by its own PMC.
+
+- **Composition:** Committed maintainers and contributors who have demonstrated merit and alignment with the CDCF mission.
+- **Responsibility:** Day-to-day management of the project, including technical direction, security, documentation, and community growth.
+- **Accountability:** The PMC is accountable to the CDCF Board through the TCSC.
+
+## 4. The CDCF Community
+
+The CDCF is an open commons. The community includes:
+
+- **Contributors:** Individuals and institutions that contribute code, documentation, or expertise.
+- **Users:** Parishes, dioceses, and Catholic organizations that deploy CDCF-vetted tools.
+- **Advisors:** Bishops, theologians, and experts who provide guidance on mission and canonical alignment.

--- a/project-governance/definitions.md
+++ b/project-governance/definitions.md
@@ -1,0 +1,29 @@
+# CDCF Governance Definitions
+
+This document provides a shared vocabulary for the Catholic Digital Commons Foundation (CDCF) governance and vetting processes.
+
+---
+
+## Foundation Roles
+
+- **CDCF Board:** The primary governing body of the Foundation.
+- **TCSC (Technical and Canonical Standards Committee):** The expert body that maintains vetting criteria and reviews project alignment.
+- **Maintainer:** An individual with write access to a project's repository and responsibility for its technical and mission-aligned growth.
+- **Contributor:** Anyone who provides input, code, or documentation to a CDCF project.
+- **Member:** An institution (diocese, school, health system) that formally supports the CDCF.
+
+## Project Stages
+
+- **Incubating:** A project that has been accepted by the TCSC but has not yet met all criteria for graduation.
+- **Active (Graduated):** A project that has satisfied all 8 vetting criteria and is recommended for wide-scale deployment.
+- **Retired (Attic):** A project that is no longer maintained but remains available for reference.
+
+## Technical & Canonical Terms
+
+- **Gate 1 (Incubation Acceptance):** The first evaluation hurdle focused on mission alignment and core accountability.
+- **Gate 2 (Graduation):** The final evaluation hurdle focused on operational readiness and sustainability.
+- **Mission Alignment:** The requirement that a project's purpose and operation be coherent with Catholic Social Teaching and the Church's evangelizing mission.
+- **Canonical Scope:** The boundaries defined by Canon Law and the Magisterium regarding what technology can and cannot do (e.g., technology cannot simulate sacramental grace).
+- **Subsidiarity:** The principle that matters ought to be handled by the smallest, lowest, or least centralized competent authority.
+- **Human Accountability Architecture:** A design requirement ensuring every consequential output is traceable to a named, responsible human being.
+- **Governance-as-Code:** The practice of expressing deployment policies as machine-readable, auditable specifications rather than static documents.

--- a/project-governance/lifecycle.md
+++ b/project-governance/lifecycle.md
@@ -1,0 +1,41 @@
+# CDCF Project Lifecycle
+
+This document describes the stages through which a technology project passes within the Catholic Digital Commons Foundation (CDCF). The process is designed to ensure mission alignment, technical excellence, and sustainable governance.
+
+---
+
+## 1. Proposal Phase
+
+Any community member or institution can propose a project for CDCF consideration.
+
+- **Submission:** A project proposal is submitted via a formal request, including a clear statement of purpose and its potential service to the Church.
+- **Initial Review:** The CDCF board or a designated committee performs an initial screening for mission alignment and canonical scope.
+
+## 2. Incubation (Gate 1)
+
+A project accepted into incubation becomes an official CDCF candidate.
+
+- **Entrance Criteria:** Satisfies Criterion 1 (Mission Alignment) and demonstrates a plan for satisfying Criteria 2-6.
+- **Objective:** Build toward Graduation by satisfying all Gate 1 and Gate 2 criteria.
+- **Mentorship:** Incubating projects may be assigned mentors to guide them through the CDCF's governance and technical standards.
+
+## 3. Graduation (Gate 2)
+
+A project graduates to active CDCF status when it has demonstrated operational readiness and long-term sustainability.
+
+- **Entrance Criteria:** Satisfies all 8 CDCF Project Vetting Criteria.
+- **Status:** Recognised as a mature, "active" CDCF project. It is considered ready for wide-scale deployment across Catholic institutions.
+
+## 4. Active Status
+
+Active projects are the core of the CDCF ecosystem.
+
+- **Ongoing Requirements:** Must maintain satisfaction of all criteria, including regular security audits, community governance, and adherence to updated standards.
+- **Governance:** Managed by a Project Management Committee (PMC) or equivalent accountable body.
+
+## 5. Retirement (The Attic)
+
+A project that is no longer actively maintained or that has been superseded by other technology may be moved to the Attic.
+
+- **Process:** Initiated by the PMC or the CDCF board when a project is no longer viable or aligned with current needs.
+- **Status:** The project remains available for historical reference but is no longer officially supported or endorsed for new deployments.

--- a/project-governance/project-types.md
+++ b/project-governance/project-types.md
@@ -1,0 +1,71 @@
+# CDCF Project Types: Foundation Projects and Community Projects
+
+The Catholic Digital Commons Foundation (CDCF) recognises two distinct categories of projects within its ecosystem: **Foundation Projects** and **Community Projects**. This distinction reflects the Foundation's dual commitment to rigorous governance of the technology it endorses, and to the visibility and flourishing of the wider Catholic developer community.
+
+---
+
+## Foundation Projects
+
+Foundation Projects are technology initiatives that have been formally submitted for CDCF consideration and have passed through the Foundation's [vetting process](./project-vetting-criteria.md).
+
+### Key characteristics
+
+- **Vetting and governance.** Foundation Projects undergo the full two-gate evaluation process (Incubation and Graduation) defined in the [Project Vetting Criteria](./project-vetting-criteria.md) and the [Project Lifecycle](./lifecycle.md).
+- **Intellectual property.** Upon acceptance as an active (graduated) project, the intellectual property of a Foundation Project belongs to the CDCF itself. This ensures long-term stewardship, continuity, and protection of the project on behalf of the Catholic community it serves.
+- **Hosting and distribution.** Foundation Projects are hosted under the CDCF's organisational infrastructure (e.g., [github.com/CatholicOS](https://github.com/CatholicOS)) and are distributed and endorsed by the Foundation.
+- **Ecclesial governance.** The CDCF is not a top-down bureaucracy, but neither is it an independent democratic body. The Foundation is participated and governed by Church institutions themselves — dioceses, episcopal conferences, and bodies of the Holy See — and operates in filial submission to the Church hierarchy. This means that governance is collaborative and community-engaged, while remaining firmly rooted in ecclesial authority and communion. Project Management Committees (PMCs) and the broader contributor community participate actively in the stewardship of Foundation Projects, but always within the framework of the Church's teaching authority and institutional structures, and in accordance with the principle of subsidiarity.
+- **Lifecycle stages.** Foundation Projects progress through defined stages: Proposal → Incubation → Graduation → Active Status (and eventually Retirement). See [lifecycle.md](./lifecycle.md) for details.
+
+### Why Foundation Projects matter
+
+By bringing a project under the CDCF umbrella, the Catholic community gains:
+
+- Assurance that the project meets standards rooted in Catholic Social Teaching, Canon Law, and technical best practice.
+- A named, accountable governance structure for every project.
+- Long-term continuity independent of any single developer or institution.
+- A trusted channel through which Catholic institutions can discover and deploy mission-aligned technology.
+
+---
+
+## Community Projects
+
+Community Projects are independently developed and maintained technology initiatives that serve the Catholic community but have **not** been submitted for or accepted into the CDCF vetting process.
+
+### Key characteristics
+
+- **No formal vetting.** Community Projects do not undergo the CDCF's two-gate evaluation. They are not assessed against the Foundation's criteria for mission alignment, accountability architecture, or deployment governance.
+- **Independent ownership.** The intellectual property of a Community Project remains with its original developers or maintainers. The CDCF does not hold, govern, or assume responsibility for the project.
+- **Not hosted or distributed by the CDCF.** Community Projects are hosted on their own infrastructure and distributed through their own channels. The CDCF does not endorse them in the same way it endorses Foundation Projects.
+- **Visibility and collaboration.** The CDCF maintains awareness of Community Projects and may list them in a community directory or catalogue. The purpose is not endorsement but **visibility** — helping Catholic developers, institutions, and ministries discover one another's work, avoid duplication of effort, and find opportunities for collaboration.
+
+### Why Community Projects matter
+
+The Catholic technology landscape is rich with locally driven initiatives — parish apps, diocesan tools, liturgical software, catechetical platforms — built by developers who serve their communities with dedication and skill. Many of these projects may never seek or need formal CDCF governance, but they are an essential part of the ecosystem.
+
+By recognising Community Projects, the CDCF:
+
+- Acknowledges and honours the work of Catholic developers worldwide.
+- Creates a space for networking, mutual support, and knowledge sharing.
+- Lowers barriers to collaboration across geographic and institutional boundaries.
+- Provides a natural pathway for projects that may eventually choose to pursue Foundation status.
+
+---
+
+## Comparison
+
+| | Foundation Projects | Community Projects |
+|:---|:---|:---|
+| **Vetting** | Full two-gate process (Incubation → Graduation) | None |
+| **Intellectual property** | Belongs to the CDCF | Remains with original developers |
+| **Hosting** | Hosted by the CDCF | Hosted independently |
+| **Distribution & endorsement** | Distributed and endorsed by the CDCF | Not endorsed by the CDCF |
+| **Governance** | PMC and CDCF governance structures, in ecclesial communion | Self-governed by maintainers |
+| **CDCF role** | Steward and governing body | Visibility and community building |
+
+---
+
+## A note on the relationship between the two
+
+The boundary between Foundation Projects and Community Projects is not a wall but a **bridge**. Community Projects are welcome to apply for Foundation status at any time. The CDCF's vetting process is designed to be transparent, supportive, and accessible — not a gatekeeping mechanism but a service to the community.
+
+Similarly, the Foundation's recognition of Community Projects is an expression of the Catholic principle of solidarity: we are stronger together, and every contribution to the digital commons — whether formally governed or independently maintained — serves the mission of the Church.

--- a/project-governance/project-vetting-criteria.md
+++ b/project-governance/project-vetting-criteria.md
@@ -1,0 +1,86 @@
+# CDCF Project Vetting Criteria: General Framework
+
+| | |
+|:---|:---|
+| **Version** | v0.1 (draft for community review) |
+| **Scope** | All technology projects submitted for CDCF incubation and graduation |
+| **Relationship** | This is the generalized framework. Specialized domains (e.g., AI) may have additional criteria. |
+
+---
+
+## Table of Contents
+
+1. [Purpose and Rationale](#purpose-and-rationale)
+2. [Gate 1: Incubation Acceptance](#gate-1-incubation-acceptance)
+   - [Criterion 1: Mission Alignment and Canonical Scope](#criterion-1-mission-alignment-and-canonical-scope)
+   - [Criterion 2: Human Accountability Architecture](#criterion-2-human-accountability-architecture)
+   - [Criterion 3: Transparency of Scope and Operation](#criterion-3-transparency-of-scope-and-operation)
+   - [Criterion 4: Independent Validation of Claimed Capabilities](#criterion-4-independent-validation-of-claimed-capabilities)
+   - [Criterion 5: Impact on Vulnerable Populations](#criterion-5-impact-on-vulnerable-populations)
+   - [Criterion 6: Deployment Governance Specification](#criterion-6-deployment-governance-specification)
+3. [Gate 2: Graduation to Active CDCF Project Status](#gate-2-graduation-to-active-cdcf-project-status)
+   - [Criterion 7: Documentation for Independent Deployment and Data Stewardship](#criterion-7-documentation-for-independent-deployment-and-data-stewardship)
+   - [Criterion 8: Governance, Maintenance, and Subsidiarity Compatibility](#criterion-8-governance-maintenance-and-subsidiarity-compatibility)
+4. [Grounding in Catholic Teaching and Canonical Tradition](#grounding-in-catholic-teaching-and-canonical-tradition)
+5. [An Invitation to Iterate](#an-invitation-to-iterate)
+
+---
+
+## Purpose and Rationale
+
+The Catholic Digital Commons Foundation (CDCF) serves the Church by fostering a shared, canonical standard for technology projects that respect human dignity and the common good. Without shared standards, Catholic institutions risk technical and canonical fragmentation, deploying tools that may not align with our mission or that operate without clear lines of accountability.
+
+This document establishes the general requirements for any project seeking CDCF endorsement. It follows a two-gate structure: **Gate 1** for incubation acceptance and **Gate 2** for graduation to active project status.
+
+| Gate | Stage | Requirement |
+|:---|:---|:---|
+| **Gate 1** | Incubation Acceptance | Criteria 1 through 6 must be satisfied. |
+| **Gate 2** | Graduation to Active Status | Criteria 7 and 8 must be satisfied, and Gate 1 criteria must remain satisfied. |
+
+---
+
+## Gate 1: Incubation Acceptance
+
+### Criterion 1: Mission Alignment and Canonical Scope
+
+The project must serve a purpose coherent with the Church's evangelizing mission and with Catholic Social Teaching. It must be respectful of human dignity, conducive to human flourishing, and of potential service to the Church at a wide level.
+
+**Canonical boundaries.** Technology projects must not attempt to simulate sacramental functions or present themselves as having ecclesial authority they do not possess. 
+
+### Criterion 2: Human Accountability Architecture
+
+Every consequential action or decision informed by the project must be attributable to a named, accountable human being. Accountability must be traceable to specific individuals operating within defined systems of consultation, in accordance with the principles of Catholic governance (cf. Canon 627).
+
+### Criterion 3: Transparency of Scope and Operation
+
+The project must provide accurate documentation of its operation, its dependencies, its data usage, and its intended impact. This documentation must be sufficient for independent technical and canonical review.
+
+### Criterion 4: Independent Validation of Claimed Capabilities
+
+The submitter must provide evidence that the project's claimed capabilities have been validated by sources independent of the primary developers (e.g., third-party audits, peer reviews, or documented benchmarking).
+
+### Criterion 5: Impact on Vulnerable Populations
+
+The project must demonstrate that its impact has been examined with particular attention to the "preferential option for the poor" and those most vulnerable to technological exclusion or harm.
+
+### Criterion 6: Deployment Governance Specification
+
+The submitter must specify the governance conditions under which the project will operate, including decision authority levels, escalation conditions, and appeal processes for those affected by the project's outputs.
+
+---
+
+## Gate 2: Graduation to Active CDCF Project Status
+
+### Criterion 7: Documentation for Independent Deployment and Data Stewardship
+
+The project must provide documentation sufficient for a Catholic institution to evaluate, configure, deploy, and support the project independently. It must also demonstrate rigorous data stewardship, complying with relevant legal and canonical requirements for data protection.
+
+### Criterion 8: Governance, Maintenance, and Subsidiarity Compatibility
+
+The project must have a documented process for ongoing maintenance and community governance. It must be architecturally compatible with the principle of subsidiarity, allowing local communities (parishes, dioceses) to retain their proper initiative and responsibility.
+
+---
+
+## Grounding in Catholic Teaching and Canonical Tradition
+
+These criteria are rooted in the Church's teaching on human dignity, the common good, and the principles of subsidiarity and solidarity. They operationalize these theological and canonical realities into technical and organizational standards for the digital commons.


### PR DESCRIPTION
## Summary
- Generalizes the governance framework beyond AI-specific projects to cover all technology projects under the CDCF
- Adds new project governance documents: committee structure, project definitions, lifecycle stages, and vetting criteria
- Updates README and AI governance docs to reflect the broader scope

## Test plan
- [ ] Review new governance documents for completeness and consistency
- [ ] Verify README accurately reflects the updated framework scope
- [ ] Confirm AI-specific governance references are preserved where appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)