### PR TITLE
Add standards section and committee governance framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,25 @@ The three research memos form an integrated argument. The fragmentation memo est
 
 ---
 
+### Standards
+
+Shared standards enable Catholic software projects to be interoperable and rooted in Catholic tradition. Standards committees — composed of ecclesial authorities, academic experts, Catholic university CS departments, and practitioners — define canonical identifiers and data representations for the realities of Catholic life.
+
+| Document | Type | Description |
+|:---|:---|:---|
+| [overview.md](./standards/overview.md) | **Policy** | Why standards matter, current and future standards, and the relationship between standards and projects. |
+| [committees.md](./standards/committees.md) | Procedure | Composition, formation, working process, and governance principles for standards committees. |
+
+#### Proposed standards (committees to be formed)
+
+| Standard | Repository | Domain |
+|:---|:---|:---|
+| **CMDDR** | [CatholicOS/cmddr](https://github.com/CatholicOS/cmddr) | Canonical identifiers for Magisterial documents |
+| **CRMETDR** | [CatholicOS/crmetdr](https://github.com/CatholicOS/crmetdr) | Canonical identifiers for Roman Missal editions |
+| **CLEDR** | [CatholicOS/cledr](https://github.com/CatholicOS/cledr) | Canonical identifiers for liturgical celebrations |
+
+---
+
 ## Magisterial Grounding
 
 | Source | Issuing Body | Year |

--- a/standards/committees.md
+++ b/standards/committees.md
@@ -1,0 +1,90 @@
+# CDCF Standards Committees
+
+## Purpose
+
+Standards committees are the bodies responsible for defining, reviewing, and maintaining CDCF standards. Each standard is developed by a dedicated committee composed of members with the domain expertise necessary to ensure that the standard faithfully and accurately represents the Catholic realities it encodes.
+
+Standards committees operate under the authority of the CDCF and in filial submission to the Church hierarchy. Their work is a service to the Church, not an independent exercise of authority.
+
+---
+
+## Composition
+
+Each standards committee must include representation from the following categories, as appropriate to the domain of the standard:
+
+### 1. Members of the Church hierarchy and hierarchical institutions
+
+Standards that represent ecclesial realities — diocesan structures, liturgical rites, magisterial documents — must be developed with the direct participation of the Church institutions that are authoritative for those realities. This may include:
+
+- Representatives of diocesan curias or episcopal conferences
+- Officials of dicasteries of the Roman Curia (where the standard touches on matters under their competence)
+- Superiors or delegates of religious institutes (where relevant)
+
+Their participation ensures that standards reflect the Church's own understanding of its structures and are received with ecclesial legitimacy.
+
+### 2. Academic experts
+
+The rigour and accuracy of CDCF standards requires the contribution of scholars with deep expertise in the relevant domain. Depending on the standard, this may include experts in:
+
+- **Theology** and **dogmatic tradition**
+- **Sacred Scripture** and biblical studies
+- **Ecclesiology** and **Canon Law**
+- **Liturgy** and sacramental theology
+- **Church history** and hagiography
+
+Catholic universities are natural homes for this expertise and are encouraged to participate through their theology, philosophy, and canon law faculties.
+
+### 3. Catholic universities with computer science departments
+
+Standards must be technically sound and implementable. Catholic universities with computer science or information science departments bring the capacity to:
+
+- Evaluate data modelling choices and identifier schemes
+- Assess interoperability with existing systems and standards (e.g., Unicode, BCP 47, ISO standards)
+- Conduct formal reviews of proposed specifications
+- Contribute research on best practices in data standardisation
+
+The involvement of Catholic universities bridges the gap between ecclesial knowledge and technical implementation, and provides a formation opportunity for students in the service of the Church.
+
+### 4. Practitioners and industry participants
+
+Those who have been building Catholic software in practice bring irreplaceable real-world knowledge. This includes:
+
+- Software companies that work for bishops' conferences, dioceses, and Church institutions
+- Independent developers who maintain widely used Catholic software (liturgical calendars, parish management tools, catechetical apps, etc.)
+- Technology teams within Catholic healthcare systems, educational networks, and charitable organisations
+
+Practitioners ensure that standards are grounded in the realities of implementation, adoption, and deployment — not only in theory.
+
+---
+
+## Formation of a standards committee
+
+A new standards committee is formed when the CDCF identifies or receives a proposal for a new area of standardisation. The process is as follows:
+
+1. **Proposal.** A standards proposal is submitted to the CDCF, identifying the domain, the need for standardisation, and the anticipated scope.
+2. **Review.** The CDCF Board and the Technical and Canonical Standards Committee (TCSC) review the proposal for alignment with the Foundation's mission and for feasibility.
+3. **Call for participation.** Upon acceptance, the CDCF issues a call for participation, inviting members from each of the four composition categories described above.
+4. **Constitution.** The committee is formally constituted with a named chair and an initial membership roster. The chair is responsible for facilitating the committee's work and reporting to the TCSC.
+5. **Charter.** The committee drafts a charter defining the scope of the standard, the intended deliverables, the review process, and the timeline.
+
+---
+
+## Working process
+
+Standards committees follow an open, iterative process:
+
+- **Drafting.** The committee produces an initial draft of the standard, drawing on existing scholarship, data sources, and practical implementations.
+- **Community review.** Drafts are published for public review. Feedback is solicited from the broader Catholic developer community, ecclesial institutions, and academic experts.
+- **Revision.** The committee revises the draft in response to feedback, documenting substantive changes and the rationale for decisions.
+- **Approval.** The final draft is submitted to the TCSC for approval. For standards touching on matters of doctrine, liturgy, or canonical structure, the appropriate ecclesial authority is consulted before final approval.
+- **Publication.** Approved standards are published in the CDCF's standards repositories and are versioned for ongoing maintenance.
+
+---
+
+## Governance principles
+
+- **Ecclesial fidelity.** Standards must faithfully represent the Church's own understanding of the realities they encode. Where the Church has defined structures, rites, or teachings, the standard must conform to those definitions.
+- **Subsidiarity.** Standards should define the minimum necessary for interoperability, leaving room for local adaptation where appropriate.
+- **Openness.** The standards development process is open to participation from the entire Catholic community. Drafts, deliberations, and decisions are documented publicly.
+- **Technical excellence.** Standards must be technically rigorous, well-documented, and implementable by developers of varying skill levels.
+- **Stability and versioning.** Published standards are versioned. Breaking changes require a new major version and a clear migration path.

--- a/standards/overview.md
+++ b/standards/overview.md
@@ -1,0 +1,54 @@
+# CDCF Standards: Overview
+
+## Why standards matter
+
+Catholic institutions worldwide develop software to serve the Church's mission — liturgical calendars, parish management systems, catechetical platforms, sacramental record-keeping tools, and much more. In the absence of shared standards, these projects operate in isolation: they define their own identifiers, structure their own data models, and make their own assumptions about how to represent the realities of Catholic life in code.
+
+The result is fragmentation. A liturgical calendar app cannot exchange data with a parish management system. A diocesan database uses one set of identifiers for its parishes while a national directory uses another. The Roman Missal editions are referenced differently across every project that needs them.
+
+**Standards solve this.** By establishing shared, canonical identifiers and data representations for the entities and realities of Catholic life, the CDCF enables:
+
+- **Interoperability.** Catholic software projects can exchange data and work together, regardless of who built them or where they are deployed.
+- **Quality assurance.** Adherence to CDCF standards signals that a project is rooted in Catholic tradition and has engaged seriously with the ecclesial realities it represents.
+- **Reduced duplication.** Developers can build on a shared foundation rather than reinventing the same data models in isolation.
+- **Ecclesial accuracy.** Standards developed with the participation of theologians, liturgists, canonists, and Church institutions ensure that software faithfully represents the Church's own understanding of its structures, rites, and traditions.
+
+---
+
+## Proposed standards
+
+The CDCF has begun proposing standards in areas where the need for interoperability is most immediate. The following are **initial proposals** — preliminary work intended to seed the conversation and provide a starting point. Each proposal will require the formation of a dedicated [standards committee](./committees.md) to review, refine, and formally develop the standard through the full committee process.
+
+| Standard | Repository | Status | Description |
+|:---|:---|:---|:---|
+| **CMDDR** — Common Magisterial Document Data Repository | [CatholicOS/cmddr](https://github.com/CatholicOS/cmddr) | Proposed | Canonical identifiers and classification for Magisterial documents of the Catholic Church (encyclicals, apostolic constitutions, motu proprii, etc.), including document type taxonomy, issuer identification, and magisterial authority level. |
+| **CRMETDR** — Common Roman Missal Editio Typica Data Repository | [CatholicOS/crmetdr](https://github.com/CatholicOS/crmetdr) | Proposed | Canonical identifiers for every published edition of the Latin Roman Missal, from the first *Missale Romanum* of 1474 through the 2008 reimpressio emendata, including a scheme for identifying vernacular translations. |
+| **CLEDR** — Common Liturgical Events Data Repository | [CatholicOS/cledr](https://github.com/CatholicOS/cledr) | Proposed | Canonical identifiers for liturgical celebrations (solemnities, feasts, memorials, etc.) in the Temporale and Sanctorale cycles, with cross-mappings to existing implementations (LitCal API, RomCal, ePrex). |
+
+> **Note:** These repositories represent proposed work, not completed standards. No standards committee has yet been formed for any of these proposals. The repositories serve as a starting point for discussion and as an invitation for the Catholic community to participate in their development through the formal committee process.
+
+---
+
+## Future standards
+
+The scope of standardisation needed is vast. The following are areas where the CDCF anticipates standards will be necessary, though work has not yet formally begun:
+
+- **Dioceses and eparchies.** Standardised identifiers for all Catholic dioceses, eparchies, archdioceses, and other particular churches worldwide, including historical entities that have been merged, suppressed, or renamed.
+- **Roman Martyrology entries.** Standardised identifiers for the entries of the *Martyrologium Romanum*, enabling interoperability among liturgical software, hagiographic databases, and catechetical platforms.
+- **Roman Pontiffs.** Standardised identifiers for all Bishops of Rome, supporting historical research, document attribution, and liturgical references.
+- **Catholic Bible editions.** Standardised identifiers for all Catholic editions of Sacred Scripture that have been published throughout history, including the *Vulgate*, the *Nova Vulgata*, and the many approved vernacular translations.
+- **Liturgical texts and translations.** Standardised representations of approved liturgical texts across languages and rites.
+- **Canonical structures.** Standardised identifiers for parishes, religious institutes, ecclesial movements, and other canonical entities.
+
+Each of these areas will require its own standards committee with appropriate domain expertise. The list above is illustrative, not exhaustive — the Catholic community is invited to propose additional areas where standardisation would serve the common good.
+
+---
+
+## Relationship to CDCF project governance
+
+CDCF standards and CDCF projects are distinct but complementary:
+
+- **Standards** define shared data models, identifiers, and representations. They are reference specifications, not software.
+- **Projects** are software implementations that may adopt and implement CDCF standards.
+
+A project's adherence to relevant CDCF standards may be considered as part of the [vetting criteria](../project-governance/project-vetting-criteria.md) for Foundation Project status, particularly under Criterion 3 (Transparency of Scope and Operation) and Criterion 8 (Governance, Maintenance, and Subsidiarity Compatibility).


### PR DESCRIPTION
## Summary
- Adds `standards/overview.md`: explains why standards matter, lists the three proposed standards (CMDDR, CRMETDR, CLEDR) with clear "proposed" status, outlines future standardisation areas (dioceses, Martyrology, Pontiffs, Bible editions, etc.)
- Adds `standards/committees.md`: defines committee composition (ecclesial authorities, academic experts, Catholic university CS departments, practitioners), formation process, working process, and governance principles
- Updates README with a new Standards section in the document stack, linking both docs and listing the proposed standards repos

## Key points
- The three existing standards repos are explicitly marked as **proposed work** with committees yet to be formed
- Standards committees operate in filial submission to the Church hierarchy
- The committee process is open, iterative, and requires ecclesial consultation before final approval

## Test plan
- [ ] Review standards overview for accuracy regarding CMDDR, CRMETDR, and CLEDR
- [ ] Review committee composition categories for completeness
- [ ] Verify README links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)