### PR TITLE
fix: update internal links for /governance/ URL hierarchy

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -125,7 +125,7 @@ jobs:
             PARENT_SLUG="${SECTION_PARENTS[$SECTION]}"
 
             echo "Converting ${DOC}.md..."
-            pandoc "${DOC}.md" --wrap=none --lua-filter=scripts/fix-internal-links.lua -f markdown -t html5 -o "${SLUG}.html"
+            pandoc "${DOC}.md" --wrap=none -M section="$SECTION" --lua-filter=scripts/fix-internal-links.lua -f markdown -t html5 -o "${SLUG}.html"
 
             HTML_CONTENT=$(cat "${SLUG}.html")
 

--- a/scripts/fix-internal-links.lua
+++ b/scripts/fix-internal-links.lua
@@ -1,7 +1,7 @@
 -- Pandoc Lua filter: rewrite internal .md links for different output targets.
 --
 -- Set the LINK_MODE environment variable (or pandoc metadata) to control behavior:
---   "website"    (default) → /slug           (absolute paths for WordPress)
+--   "website"    (default) → /governance/<section>/slug (absolute paths for WordPress)
 --   "html"                 → slug.html       (relative paths for standalone HTML files)
 --   "combined"             → #heading-anchor (fragment links within the combined PDF)
 --
@@ -10,11 +10,15 @@
 --   - Standards docs get a "standards-" prefix to avoid slug collisions
 
 local mode = os.getenv("LINK_MODE") or "website"
+local current_section = os.getenv("LINK_SECTION") or nil
 
--- Read mode from pandoc metadata as fallback
+-- Read mode and section from pandoc metadata as fallback
 function Meta(meta)
   if meta["link-mode"] then
     mode = pandoc.utils.stringify(meta["link-mode"])
+  end
+  if meta["section"] then
+    current_section = pandoc.utils.stringify(meta["section"])
   end
 end
 
@@ -59,8 +63,13 @@ function Link(el)
       el.target = '#' .. base
     end
   else
-    -- website mode (default)
-    el.target = '/' .. base .. anchor
+    -- website mode (default): /governance/<section>/<slug>
+    local section = dir or current_section
+    if section then
+      el.target = '/governance/' .. section .. '/' .. base .. anchor
+    else
+      el.target = '/governance/' .. base .. anchor
+    end
   end
 
   return el


### PR DESCRIPTION
## Summary
- Updates the Lua link filter to generate `/governance/<section>/<slug>` paths in website mode (was `/<slug>`)
- Passes the current section as pandoc metadata (`-M section`) so same-directory `./` links resolve correctly
- No changes to HTML or PDF build modes — only affects WordPress deploy

Companion change to CatholicOS/cdcf-website@246ba2b which restructured governance pages into `/governance/project-governance/`, `/governance/ai-governance/`, and `/governance/standards/` hierarchies.

## Test plan
- [ ] Trigger a manual deploy and verify internal links in published pages point to `/governance/<section>/<slug>`
- [ ] Verify standalone HTML build still works (`npm run build:html`)
- [ ] Verify combined PDF build still works (`npm run build:pdf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)