### PR TITLE
fix(deploy): make verify step tolerate transient curl errors

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -308,20 +308,26 @@ jobs:
           # without this step a silent worker failure (OpenAI timeout, missing
           # API key, dead Redis worker) lets the deploy report success while
           # leaving translations stale.
-          MAX_ATTEMPTS=20      # 20 x 30s = 10 minutes
+          MAX_ATTEMPTS=60      # 60 x 30s = 30 minutes
           SLEEP_SECONDS=30
 
           declare -A PENDING
           for ID in $TRANSLATED_IDS; do PENDING[$ID]=1; done
+          INITIAL_COUNT=${#PENDING[@]}
 
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
             REMAINING=()
             for ID in "${!PENDING[@]}"; do
-              RESPONSE=$(curl -s \
+              # `|| echo '{}'` keeps `set -e` from killing the whole step on
+              # transient curl failures (we observed exit 56 / CURLE_RECV_ERROR
+              # mid-poll). `--retry` handles short network blips at the curl
+              # layer; the `|| echo` is the safety net for everything else.
+              RESPONSE=$(curl -s --max-time 15 --retry 3 --retry-delay 5 --retry-all-errors \
                 -u "$WP_APP_USERNAME:$WP_APP_PASSWORD" \
-                "$WP_REST_URL/wp/v2/pages/${ID}?_fields=id,modified_gmt,status&context=edit")
-              MODIFIED=$(echo "$RESPONSE" | jq -r '.modified_gmt // empty')
-              STATUS=$(echo "$RESPONSE" | jq -r '.status // empty')
+                "$WP_REST_URL/wp/v2/pages/${ID}?_fields=id,modified_gmt,status&context=edit" \
+                || echo '{}')
+              MODIFIED=$(echo "$RESPONSE" | jq -r '.modified_gmt // empty' 2>/dev/null || echo "")
+              STATUS=$(echo "$RESPONSE" | jq -r '.status // empty' 2>/dev/null || echo "")
 
               # modified_gmt is ISO 8601 with no offset; lexicographic compare
               # against DEPLOY_START_GMT (also UTC, no offset) is correct.
@@ -343,7 +349,8 @@ jobs:
               exit 0
             fi
 
-            echo "Attempt ${attempt}/${MAX_ATTEMPTS}: ${#PENDING[@]} pending - sleeping ${SLEEP_SECONDS}s..."
+            COMPLETED=$((INITIAL_COUNT - ${#PENDING[@]}))
+            echo "Attempt ${attempt}/${MAX_ATTEMPTS}: ${COMPLETED}/${INITIAL_COUNT} done, ${#PENDING[@]} pending - sleeping ${SLEEP_SECONDS}s..."
             sleep "$SLEEP_SECONDS"
           done
 


### PR DESCRIPTION
## Summary

The verify step from #22 exited with code 56 (CURLE_RECV_ERROR) on its
second polling attempt during a workflow_dispatch run today, killing
the workflow on a single transient network blip. Three robustness
fixes:

- **`set -e` safety net** — append `|| echo '{}'` to each `curl` call
  so the script keeps running through transient failures. The empty
  JSON makes `jq` return empty strings, which keeps the page in
  `PENDING` for the next attempt (correct: "not yet translated").
- **Curl-layer retry** — `--max-time 15 --retry 3 --retry-delay 5
  --retry-all-errors` for short network blips at the transport layer.
- **Bigger window** — `MAX_ATTEMPTS=60` (30 min, was 10). On
  `workflow_dispatch` (DEPLOY_ALL=true) we enqueue up to 50
  translations and observed throughput is ~1 every 5-8s; the old
  10-minute cap couldn't fit a full bulk recovery.

Also: progress messages now show `"X/N done"` for at-a-glance status.

## Why now

Today's `workflow_dispatch` recovery run (run 25120538762) enqueued
50 translations, and the verify step failed at attempt 2 with curl
exit 56 — leaving the run reported as failed even though 30+
translations did succeed in the background. This patch lets the
verify step ride out brief network blips and gives enough time for
a 50-job bulk recovery to actually finish.

## Test plan

- [ ] Re-trigger the deploy workflow once OpenAI's HTTP 502s on
      large-content translations clear; confirm the verify step
      polls cleanly through the full window
- [ ] Confirm the new "X/N done" progress messages appear in the
      run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)