### PR TITLE
chore: group Dependabot updates and fix auto-merge method

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,12 @@
 version: 2
+
+# Action pin policy: workflows in this repo MUST reference third-party actions
+# by commit SHA with a trailing version comment, e.g.
+#   uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+# Dependabot detects that format and rewrites both the SHA and the comment
+# when a new release ships, keeping the pin intact. Tag-only pins (`@v6`) are
+# mutable and silently widen the trust surface — do not introduce them.
+
 updates:
   - package-ecosystem: npm
     directory: /
@@ -9,6 +17,11 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
@@ -20,3 +33,8 @@ updates:
       - dependencies
       - github-actions
     open-pull-requests-limit: 10
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -22,7 +22,8 @@ jobs:
 
       - name: Auto-merge non-major updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge "$PR_URL" --auto --squash
+        # Repo policy permits merge commits only (allow_squash_merge / allow_rebase_merge are off).
+        run: gh pr merge "$PR_URL" --auto --merge
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Two related changes to make the Dependabot pipeline both quieter and actually functional.

### 1. `chore(deps)` — group minor/patch updates and document the SHA-pin policy

- **Grouping**: minor + patch bumps for `npm` and `github-actions` now batch into one weekly PR per ecosystem instead of one per dependency. Majors stay ungrouped so they keep human review.
- **Policy comment**: a header note in `.github/dependabot.yml` records that workflow files must reference third-party actions by commit SHA with a trailing version comment (`actions/checkout@<sha> # v6`). Dependabot rewrites both the SHA and the comment atomically; tag-only pins are forbidden because they widen the trust surface silently.

### 2. `fix(actions)` — use merge commit instead of squash for Dependabot auto-merge

The repo allows merge commits only (`allow_squash_merge` and `allow_rebase_merge` are both off). The auto-merge workflow was calling `gh pr merge --auto --squash`, which the GitHub merge endpoint rejected with `Squash merges are not allowed on this repository`. **Every recent non-major Dependabot PR failed at the merge step**; only major-version runs passed, because their merge step was filtered out by the `update-type` guard — that masked the breakage in the run history.

Switching to `--merge` aligns the workflow with the repo's policy.

## Test plan

- [ ] Confirm CI passes on this PR (markdown-lint workflow)
- [ ] After merge, comment `@dependabot recreate` on each non-major open Dependabot PR (#27, #28, #29, #31) so the new workflow re-evaluates them; verify auto-merge enables and the merge succeeds with a merge commit
- [ ] Spot-check #27 (`pandoc/actions` SHA bump) — Dependabot rendered it as a raw-SHA-only title. Verify the resulting workflow diff still keeps the trailing `# v...` comment intact rather than stripping it
- [ ] On the next weekly Dependabot run, confirm minor/patch bumps arrive as a single grouped PR per ecosystem