### PR TITLE
ci: add Build Test workflow as the required status check

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,45 @@
+name: Build Test
+
+# Mirrors the build steps from deploy-docs.yml so that any PR that would
+# break the deploy fails CI here first. Runs unconditionally on every PR
+# and every push to main, providing the always-on required status check
+# for branch protection. The deploy-only steps (WordPress upload,
+# translation, GitHub release) are not exercised — they require live
+# external services and run only on tag.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    name: Build governance docs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install pandoc
+        uses: pandoc/actions/setup@86321b6dd4675f5014c611e05088e10d4939e09e # v1.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
+
+      - name: Build standalone HTML pages
+        run: npm run build:html
+
+      - name: Build combined PDF
+        run: npm run build:pdf
+        env:
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome-stable


### PR DESCRIPTION
## Summary

Adds `.github/workflows/build-test.yml` — a CI workflow that runs the **build half** of `deploy-docs.yml` (pandoc setup, `npm ci`, `build:html`, `build:pdf`) on every PR and on push to `main`. Catches the failure modes that currently only surface at deploy time:

- **Lockfile drift** (`npm ci` fails)
- **Pandoc / lua filter errors** (`build:html` fails)
- **PDF rendering / pagedjs / Chrome failures** (`build:pdf` fails)

The deploy-only steps — WordPress REST upload, translation worker, GitHub release — aren't exercised here; they need live external services and only run on tag.

## Why this instead of running Lint Markdown on every PR

Lint Markdown is path-filtered to `**/*.md` for good reason: it's irrelevant to PRs that don't touch markdown (e.g. Dependabot bumping a workflow SHA). Removing its path filter would have given us the required-check anchor for branch protection but at the cost of a useless 30-second job on every Dependabot PR. A build test is more meaningful: it actually validates that the PR doesn't break what `main` is supposed to ship.

## Follow-up after merge

Once this lands and runs once on a PR (so the check name `Build governance docs` is registered in the API), enable branch protection on `main`:

- Require pull request before merging
- Require `Build governance docs` status check to pass
- Block force-push and branch deletion

With that in place, the dependabot auto-merge workflow's `gh pr merge --auto --merge` will reliably have a check to wait on, fixing the residual race seen on PR #28.

## Test plan

- [ ] Verify Build Test runs on this PR and succeeds
- [ ] After merge, enable branch protection on `main` per above
- [ ] Confirm next Dependabot PR's auto-merge enables cleanly (`--auto` finds the required check)