### PR TITLE
chore(deps): override tar-fs and ws to clear transitive CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3305,13 +3305,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4529,15 +4522,18 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/tar-stream": {
@@ -4819,9 +4815,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
     "markdownlint-cli2": "^0.22.1",
     "pagedjs-cli": "^0.4.3",
     "prettier": "^3.8.3"
+  },
+  "overrides": {
+    "tar-fs": "^3.1.2",
+    "ws": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary

Resolves all four open Dependabot security alerts (3× `tar-fs`, 1× `ws`) by adding npm `overrides` that force patched versions of transitive deps that `pagedjs-cli@0.4.3 → puppeteer@^20.9.0 → @puppeteer/browsers@1.4.6` would otherwise hold back.

| Package | Before | After | Why |
|---|---|---|---|
| `tar-fs` | 3.0.4 | **3.1.2** | Clears 3 CVEs (symlink bypass, extraction escape, link-following) — all patched at 3.1.1+ |
| `ws` | 8.13.0 | **8.20.0** | Clears DoS-via-many-headers — patched at 8.17.1+ |

`npm install` reports **0 vulnerabilities** post-override.

## Why an upstream bump won't fix this

- `pagedjs-cli@0.4.3` is the latest stable. `0.5.0-beta.2` would pull in `puppeteer@22.x` (which uses safe `tar-fs`), and `1.0.0-alpha.2` is abandoned with even older puppeteer.
- pagedjs-cli's GitHub repo has zero releases tagged — the project is in maintenance mode.
- Dependabot can only nudge top-level deps; it can't move `tar-fs` past what `puppeteer@20.x` permits.

## Practical exploitability

Low across the board, but worth fixing anyway:

- Deploy and Build Test both use `PUPPETEER_SKIP_DOWNLOAD: 'true'`, so `tar-fs` (the Chrome-tarball extractor used at install time by `@puppeteer/browsers`) is **never invoked** — we use system Chrome via `PUPPETEER_EXECUTABLE_PATH`.
- `ws` is used as a client to local Chrome's DevTools port; the DoS vuln is on the WebSocket *server* side. Not externally reachable.

## Test plan

- [ ] `Build governance docs` passes on this PR (validates the PDF build still renders correctly with overridden tar-fs/ws)
- [ ] After merge, confirm Dependabot alert dashboard goes to 0 open alerts

## Future

Once `pagedjs-cli` ships a stable on `puppeteer@22.x` or newer, drop the overrides — they'll be redundant.